### PR TITLE
Fix bedtools truncate and exclude coverage

### DIFF
--- a/GQC/alignparse.py
+++ b/GQC/alignparse.py
@@ -54,7 +54,7 @@ def write_bedfiles(bamobj, pafaligns, refobj, queryobj, hetsites, testmatbed, te
                     variants.extend(align_variants(align, queryobj, query, querystart, queryend, refobj, ref, refstart, refend, strand, hetsites, hetsitealleles, alignedscorecounts, snverrorscorecounts, indelerrorscorecounts, True))
         # mark variants that are in excluded regions:
         logger.debug("Beginning to exclude variants in excluded regions")
-        if excludedbedobj:
+        if excludedbedobj is not None and len(excludedbedobj) > 0:
             variants = exclude_variants(variants, excludedbedobj)
             logger.debug("Finished excluding variants in excluded regions")
     else:
@@ -719,26 +719,29 @@ def exclude_variants(variants:list, excludedregionsobj:pybedtools.BedTool)->list
     numvariants = len(variants)
     logger.debug("There are " + str(numvariants) + " variants")
     variantbedstringlist = []
-    for variant in variants:
+    # bedtools truncates the BED name field (~1kb); variant names embed full
+    # ref/query alleles for large indels, so use stable numeric ids for intersect.
+    for variantindex, variant in enumerate(variants):
         chrom = variant.chrom
-        start = variant.start
-        end = variant.end
-        name = variant.name
-        variantbedstringlist.append(chrom + "\t" + str(start) + "\t" + str(end) + "\t" + name + "\n")
+        bed_start = min(int(variant.start), int(variant.end))
+        bed_end = max(int(variant.start), int(variant.end))
+        if bed_end <= bed_start:
+            bed_end = bed_start + 1
+        variantbedstringlist.append(chrom + "\t" + str(bed_start) + "\t" + str(bed_end) + "\t" + str(variantindex) + "\n")
 
     variantbedstring = ''.join(variantbedstringlist)
     variantbedobj = pybedtools.BedTool(variantbedstring, from_string=True)
     logger.debug("Created BedTool object")
     excludedvariants = bedtoolslib.intersectintervals(variantbedobj, excludedregionsobj, wa=True)
-    excludeddict = {}
+    excludedindices = set()
     for excludedvariant in excludedvariants:
-        excludeddict[excludedvariant.name] = True
+        excludedindices.add(int(excludedvariant.name))
 
     newvariants = []
     numexcluded = 0
     numretained = 0
-    for variant in variants:
-        if variant.name in excludeddict.keys():
+    for variantindex, variant in enumerate(variants):
+        if variantindex in excludedindices:
             newvariants.append(varianttuple(chrom=variant.chrom, start=variant.start, end=variant.end, name=variant.name, vartype=variant.vartype, excluded = True, qvscore=variant.qvscore))
             numexcluded = numexcluded + 1
         else:

--- a/GQC/alignparse.py
+++ b/GQC/alignparse.py
@@ -819,13 +819,25 @@ def read_bam_aligns(bamobj, mintargetlength=0)->list:
 
     return alignlist
 
+def populate_numnonexcludedbases(refobj, bedobjects:dict, benchmark_stats:dict)->None:
+    # since allexcludedregions bed object is merged, can subtract out excluded bases interval by interval
+    benchmark_stats["numnonexcludedbases"] = {}
+    for ref in refobj.references:
+        benchmark_stats["numnonexcludedbases"][ref] = refobj.get_reference_length(ref)
+    allexcludedregions = bedobjects.get("allexcludedregions")
+    if allexcludedregions is not None and len(allexcludedregions) > 0:
+        for interval in allexcludedregions:
+            ref = interval.chrom
+            if ref in benchmark_stats["numnonexcludedbases"].keys():
+                benchmark_stats["numnonexcludedbases"][ref] = benchmark_stats["numnonexcludedbases"][ref] - len(interval)
+
 # this routine assumes query start > query end for reverse strand alignments
 def assess_overall_structure(aligndata:list, refobj, queryobj, outputfiles, bedobjects, benchmark_stats, args):
 
     # create a "clustercoverage" dictionary that will contain each chromosome's number of clusters and bases covered
     benchmark_stats["clustercoverage"] = {}
     benchmark_stats["alignclusters"] = {}
-    benchmark_stats["numnonexcludedbases"] = {}
+    populate_numnonexcludedbases(refobj, bedobjects, benchmark_stats)
 
     # maximum separating distance along target to include in one cluster of alignments
     maxdistance = args.maxclusterdistance
@@ -833,16 +845,6 @@ def assess_overall_structure(aligndata:list, refobj, queryobj, outputfiles, bedo
     # create a directory for alignment line plots for each chromosome:
     output.create_output_directory(outputfiles["alignplotdir"])
     alignplotprefix = outputfiles["alignplotprefix"]
-
-    # calculate number of non-excluded bases for each ref entry:
-    # since allexcludedregions bed object is merged,can subtract out excluded bases interval by interval
-    for ref in refobj.references:
-        benchmark_stats["numnonexcludedbases"][ref] = refobj.get_reference_length(ref)
-    if bedobjects["allexcludedregions"] is not None:
-        for interval in bedobjects["allexcludedregions"]:
-            ref = interval.chrom
-            if ref in benchmark_stats["numnonexcludedbases"].keys():
-                benchmark_stats["numnonexcludedbases"][ref] = benchmark_stats["numnonexcludedbases"][ref] - len(interval)
     
     aligndict = {}
     for align in aligndata:

--- a/GQC/bench.py
+++ b/GQC/bench.py
@@ -325,6 +325,10 @@ def main() -> None:
        [mergedtestmatcoveredbed, outputfiles["mergedtestmatcovered"]] = bedtoolslib.mergebed(outputfiles["testmatcovered"])
        [mergedtestpatcoveredbed, outputfiles["mergedtestpatcovered"]] = bedtoolslib.mergebed(outputfiles["testpatcovered"])
 
+       # Step 6 may be skipped when cluster files already exist; still need non-excluded denominators.
+       if "numnonexcludedbases" not in benchmark_stats:
+           alignparse.populate_numnonexcludedbases(refobj, bedregiondict, benchmark_stats)
+
        logger.info("Step 8 (of 12): Writing primary alignment statistics about " + args.assembly + " assembly")
        stats.write_merged_aligned_stats(refobj, queryobj, mergedtruthcoveredbed, mergedincludedtruthcoveredbed, mergedtestmatcoveredbed, mergedtestpatcoveredbed, outputfiles, benchmark_stats, benchparams, args)
 

--- a/GQC/bench.py
+++ b/GQC/bench.py
@@ -339,7 +339,7 @@ def main() -> None:
 #
            ## evaluate mononucleotide runs:
            logger.info("Step 11 (of 12): Assessing accuracy of mononucleotide runs")
-           bedtoolslib.intersectbed(benchparams["mononucruns"], outputfiles["mergedtruthcovered"], outputfile=outputfiles["coveredmononucsfile"], writefirst=True)
+           bedtoolslib.intersectbed(benchparams["mononucruns"], outputfiles["mergedincludedtruthcovered"], outputfile=outputfiles["coveredmononucsfile"], writefirst=True)
            bedtoolslib.intersectbed(outputfiles["coveredmononucsfile"], outputfiles["allexcludedbed"], outputfile=outputfiles["coveredincludedmononucsfile"], writefirst=True, v=True)
            [mononucswithvariantsbed, mononucswithvariantsbedfile] = bedtoolslib.intersectbed(outputfiles["coveredincludedmononucsfile"], outputfiles["bencherrortypebed"], outputfiles["mononucswithvariantsfile"], outerjoin=True, writeboth=True)
            mononucstats = errors.gather_mononuc_stats(outputfiles["mononucswithvariantsfile"], outputfiles["mononucstatsfile"])

--- a/GQC/stats.py
+++ b/GQC/stats.py
@@ -5,6 +5,18 @@ import pybedtools
 
 logger = logging.getLogger(__name__)
 
+def calculate_haplotype_bases(basecounts:dict, phap1, phap2)->tuple:
+
+    hap1totalbases = 0
+    hap2totalbases = 0
+    for chrom, chrombases in basecounts.items():
+        if phap1.match(chrom):
+            hap1totalbases = hap1totalbases + chrombases
+        if phap2.match(chrom):
+            hap2totalbases = hap2totalbases + chrombases
+
+    return hap1totalbases, hap2totalbases
+
 def write_general_assembly_stats(refobj, queryobj, contigregions, gapregions, outputfiles, benchparams, args)->dict:
 
     bmstats = {}
@@ -163,54 +175,62 @@ def write_merged_aligned_stats(refobj, queryobj, mergedtruthcoveredbed, included
     patpattern = benchparams['patpattern']
     phap1 = re.compile(r".*" + re.escape(matpattern) + ".*", re.IGNORECASE)
     phap2 = re.compile(r".*" + re.escape(patpattern) + ".*", re.IGNORECASE)
+
+    hap1totalbases = bmstats['hap1totalbases']
+    hap2totalbases = bmstats['hap2totalbases']
+    if "numnonexcludedbases" in bmstats:
+        hap1totalbases, hap2totalbases = calculate_haplotype_bases(bmstats["numnonexcludedbases"], phap1, phap2)
+        benchmarkbasesdescription = "non-excluded MAT and PAT bases in benchmark"
+        matbasesdescription = "non-excluded MAT bases in benchmark"
+        patbasesdescription = "non-excluded PAT bases in benchmark"
+    else:
+        benchmarkbasesdescription = "all MAT and PAT bases in benchmark"
+        matbasesdescription = "MAT bases in benchmark"
+        patbasesdescription = "PAT bases in benchmark"
+    totalbenchbases = hap1totalbases + hap2totalbases
+
+    # Continuity and benchmark coverage stats exclude regions in --excludefile / config.
+    statstruthcoveredbed = includedtruthcoveredbed
     totalbenchcovered = 0
     totalincludedbenchcovered = 0
 
     totalrefaligned = 0
     numberrefaligns = 0
 
-    totalbases = bmstats['diploidtotalbases'] # total bases in benchmark
-
-    if totalbases > 0:
+    if totalbenchbases > 0:
         nga50 = 0
         lga50 = 0
         nga90 = 0
         lga90 = 0
         aunga = 0
 
-    for truthint in sorted(mergedtruthcoveredbed, key=lambda h: len(h), reverse=True):
+    for truthint in sorted(statstruthcoveredbed, key=lambda h: len(h), reverse=True):
         alignlength = len(truthint)
         totalrefaligned = totalrefaligned + alignlength
         numberrefaligns = numberrefaligns + 1
 
-        if totalbases > 0:
-            if totalrefaligned >= 0.5*totalbases and nga50 == 0:
+        if totalbenchbases > 0:
+            if totalrefaligned >= 0.5*totalbenchbases and nga50 == 0:
                 nga50 = alignlength
                 lga50 = numberrefaligns
-            if totalrefaligned >= 0.9*totalbases and nga90 == 0:
+            if totalrefaligned >= 0.9*totalbenchbases and nga90 == 0:
                 nga90 = alignlength
                 lga90 = numberrefaligns
-            aunga = aunga + alignlength*alignlength/totalbases
+            aunga = aunga + alignlength*alignlength/totalbenchbases
 
     matbenchcovered = 0
     patbenchcovered = 0
-    for truthint in mergedtruthcoveredbed:
-        [chrom, start, end, name] = truthint
+    for truthint in statstruthcoveredbed:
         chrom = truthint.chrom
         start = int(truthint.start)
         end = int(truthint.stop)
-        totalbenchcovered = totalbenchcovered + end - start
+        intervalbases = end - start
+        totalbenchcovered = totalbenchcovered + intervalbases
+        totalincludedbenchcovered = totalincludedbenchcovered + intervalbases
         if phap1.match(chrom):
-            matbenchcovered = matbenchcovered + end - start
+            matbenchcovered = matbenchcovered + intervalbases
         if phap2.match(chrom):
-            patbenchcovered = patbenchcovered + end - start
-
-    for truthint in includedtruthcoveredbed:
-        [chrom, start, end, name] = truthint
-        chrom = truthint.chrom
-        start = int(truthint.start)
-        end = int(truthint.stop)
-        totalincludedbenchcovered = totalincludedbenchcovered + end - start
+            patbenchcovered = patbenchcovered + intervalbases
 
     longesttestalignment = 0
     totaltestmatcovered = 0
@@ -234,7 +254,7 @@ def write_merged_aligned_stats(refobj, queryobj, mergedtruthcoveredbed, included
 
     with open(generalstatsfile, "a") as gsfh:
         gsfh.write("Aligned contig bases:\n\n")
-        if totalbases > 0:
+        if totalbenchbases > 0:
             gsfh.write("NGA50: " + str(round(nga50/1000000, 3)) + "Mb\n")
             gsfh.write("LGA50: " + str(lga50) + "\n")
             gsfh.write("NGA90: " + str(round(nga90/1000000, 3)) + "Mb\n")
@@ -242,24 +262,24 @@ def write_merged_aligned_stats(refobj, queryobj, mergedtruthcoveredbed, included
             gsfh.write("auNGA: " + str(round(aunga/1000000, 3)) + "Mb\n")
         perctestmatcovered = int(totaltestmatcovered * 1000 / bmstats['totallargecontigbases'] + 0.5) / 10
         perctestpatcovered = int(totaltestpatcovered * 1000 / bmstats['totallargecontigbases'] + 0.5) / 10
-        if bmstats['hap1totalbases'] > 0 or bmstats['hap2totalbases'] > 0:
-            percbenchcovered = int(1000 * totalbenchcovered / (bmstats['hap1totalbases'] + bmstats['hap2totalbases']) + 0.5) / 10
+        if totalbenchbases > 0:
+            percbenchcovered = int(1000 * totalbenchcovered / totalbenchbases + 0.5) / 10
         else:
             percbenchcovered = 'NA'
-        if bmstats['hap1totalbases'] > 0:
-            percmatbenchcovered = int(1000 * matbenchcovered / bmstats['hap1totalbases'] + 0.5) / 10
+        if hap1totalbases > 0:
+            percmatbenchcovered = int(1000 * matbenchcovered / hap1totalbases + 0.5) / 10
         else:
             percmatbenchcovered = 'NA'
-        if bmstats['hap2totalbases'] > 0:
-            percpatbenchcovered = int(1000 * patbenchcovered / bmstats['hap2totalbases'] + 0.5) / 10
+        if hap2totalbases > 0:
+            percpatbenchcovered = int(1000 * patbenchcovered / hap2totalbases + 0.5) / 10
         else:
             percpatbenchcovered = 'NA'
         gsfh.write("Total " + args.assembly + " bases in aligns to MAT chromosomes: " + str(totaltestmatcovered) + "/" + str(bmstats['totallargecontigbases']) + " (" + str(perctestmatcovered) + "% of total bases in contigs >= " + str(args.mincontiglength) + " bases)" + "\n")
         gsfh.write("Total " + args.assembly + " bases in aligns to PAT chromosomes: " + str(totaltestpatcovered) + "/" + str(bmstats['totallargecontigbases']) + " (" + str(perctestpatcovered) + "% of total bases in contigs >= " + str(args.mincontiglength) + " bases)" + "\n")
         gsfh.write("Longest " + args.assembly + " alignment length (in test assembly bases) to the benchmark: " + str(round(longesttestalignment/1000000, 3)) + "Mb\n")
-        gsfh.write("Total " + args.benchmark + " covered: " + str(totalbenchcovered) + "/" + str(bmstats['totalbases']) + " (" + str(percbenchcovered) + "% of all MAT and PAT bases in benchmark)" + "\n" )
-        gsfh.write("MAT " + args.benchmark + " covered: " + str(matbenchcovered) + "/" + str(bmstats['hap1totalbases']) + " (" + str(percmatbenchcovered) + "% of MAT bases in benchmark)" + "\n")
-        gsfh.write("PAT " + args.benchmark + " covered: " + str(patbenchcovered) + "/" + str(bmstats['hap2totalbases']) + " (" + str(percpatbenchcovered) + "% of PAT bases in benchmark)" + "\n")
+        gsfh.write("Total " + args.benchmark + " covered: " + str(totalbenchcovered) + "/" + str(totalbenchbases) + " (" + str(percbenchcovered) + "% of " + benchmarkbasesdescription + ")" + "\n" )
+        gsfh.write("MAT " + args.benchmark + " covered: " + str(matbenchcovered) + "/" + str(hap1totalbases) + " (" + str(percmatbenchcovered) + "% of " + matbasesdescription + ")" + "\n")
+        gsfh.write("PAT " + args.benchmark + " covered: " + str(patbenchcovered) + "/" + str(hap2totalbases) + " (" + str(percpatbenchcovered) + "% of " + patbasesdescription + ")" + "\n")
 
         if "ngc50" in bmstats.keys():
             maxclusterdistance = args.maxclusterdistance


### PR DESCRIPTION
I am trying to resolve two issues in this pull request:
1. In `alignparse.py`, when excluding variants located in excluded regions, extremely large variants can produce really long `variant.name` due to both the reference and query sequence are embedded in `variant.name`.  However, `bedtools` truncates these extremely long names, causing the exclusion of these variants failed.
2. In the `generalstats.txt` report, coverage-related metrics such as coverage percentage, auNGA, NGA, LGA still include information from excluded regions.  I addressed this in the last two commits.  However, this may introduce an asymmetry issue: for benchmark reference-based coverage percentage, excluded regions are removed from both the numerator and denominator, but in query-based coverage percentage, only the numerator is excluded.  One possible solution would be to also remove query sequences mapped to excluded benchmark regions from the denominator.  But implementing this would be a more extensive modification.